### PR TITLE
More Fastlane setup used at Acast

### DIFF
--- a/Acast/Appfile
+++ b/Acast/Appfile
@@ -1,1 +1,3 @@
-apple_id "jagcesar@example.com" # Your Apple email address
+apple_id ENV["DEVELOPER_EMAIL"] # Your Apple email address
+team_id "EW6V7PFV42" # Developer Portal Team ID
+itc_team_id "58455827" # iTunes Connect Team ID

--- a/Acast/Deliverfile
+++ b/Acast/Deliverfile
@@ -1,3 +1,4 @@
-username "jagcesar@example.com" # the iTunes Connect login email address
-
 copyright "#{Time.now.year} Acast AB"
+
+automatic_release false
+app_identifier "com.acast.app.native.production"

--- a/Acast/Fastfile
+++ b/Acast/Fastfile
@@ -4,19 +4,50 @@ default_platform :ios
 
 platform :ios do
   before_all do
+    if File.exist?("appleId")
+      ENV["DEVELOPER_EMAIL"] = File.read("appleId")
+    else
+      ENV["DEVELOPER_EMAIL"] = "jagcesar@example.com"
+    end
     ENV["SLACK_URL"] = "https://hooks.slack.com/services/[webhook-url]" # Webhook URL created in Slack
   end
 
-  desc "Installs FixCode which disables the \"Fix Issue\" button in Xcode"
-  lane :xcode do
+  desc "Call this lane when setting up a new development machine"
+  desc "Remember to install Cocoapods before you run this by running `sudo gem install cocoapods`"
+  desc "It does the following:"
+  desc "- Asks you to enter your apple-id which will be used to authorize you on iTunes Connect"
+  desc "- Copies the device frames we use for our screenshots to your home directory"
+  desc "- Installs the pods our app is dependant on"
+  desc "- Installs Xcode CLI"
+  desc "- Installs Homebrew"
+  desc "- Installs SwiftLint"
+  desc "- Installs FixCode"
+  desc "- Downloads and installs the required provisioning profiles"
+  lane :setup do
+    appleId = prompt(text: "Welcome to the Acast iOS Team!❤️\nEnter your apple-id: ")
+    File.write("appleId", appleId)
+    ENV["DEVELOPER_EMAIL"] = File.read("appleId")
+    sh "cp -r screenshots/.frameit/ ~/"
+    cocoapods
+    if !File.exist?("/usr/bin/xcode-select")
+      sh "xcode-select --install"
+    end
+    if File.exist?("/usr/local/bin/brew")
+      sh "brew update"
+    else
+      sh "/usr/bin/ruby -e \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\""
+    end
+    sh "brew install swiftlint"
     install_xcode_plugin(
       url: "https://github.com/fastlane/FixCode/releases/download/0.2.0/FixCode.xcplugin.zip"
     )
+    certs
   end
 
-  desc "Fetches the provisioning profiles so you can build locally and deploy to your device"
+  desc "Downloads the provisioning profiles so you can build locally and deploy to your device"
   lane :certs do
     match(app_identifier: "com.acast.app.debug", type: "development")
+    match(app_identifier: "com.acast.app.native.production.internalbeta", type: "development")
     match(app_identifier: "com.acast.app.native.production.internalbeta", type: "appstore")
     match(app_identifier: "com.acast.app.native.production", type: "appstore")
   end
@@ -31,13 +62,19 @@ platform :ios do
     end
   end
 
-  desc "Creates new screenshots and uploads them to iTunes Connect"
-  lane :screens do
-    cocoapods
-    match(app_identifier: "com.acast.app.debug", type: "development")
-    snapshot
-    frameit
-    deliver(app: 925311796, app_identifier: "com.acast.app.native.production", skip_metadata: true, force: true)
+  desc "Bumps version. Type: patch"
+  lane :version_patch do
+    increment_version_number(bump_type: "patch")
+  end
+
+  desc "Bumps version. Type: minor"
+  lane :version_minor do
+    increment_version_number(bump_type: "minor")
+  end
+
+  desc "Bumps version. Type: major"
+  lane :version_major do
+    increment_version_number(bump_type: "major")
   end
 
   desc "Submits a new Beta Build to Apple TestFlight"
@@ -48,16 +85,33 @@ platform :ios do
     pilot(app_identifier: "com.acast.app.native.production.internalbeta")
   end
 
-  desc "Deploys a new version to the App Store"
+  desc "Uploads the metadata to iTunes Connect"
+  lane :meta do
+    deliver(app: 925311796, app_identifier: "com.acast.app.native.production", skip_screenshots: true, skip_upload: true, force: true)
+  end
+
+  desc "Creates new screenshots and uploads them to iTunes Connect"
+  lane :screenshots do
+    cocoapods
+    match(app_identifier: "com.acast.app.debug", type: "development")
+    snapshot
+    frameit
+    deliver(app: 925311796, app_identifier: "com.acast.app.native.production", skip_metadata: true, skip_upload: true, force: true)
+  end
+
+  desc "Compiles the app, uploads it to iTunes Connect and submits it for review"
   lane :deploy do
     cocoapods
     match(app_identifier: "com.acast.app.native.production", type: "appstore")
     gym(configuration: "Release")
-    deliver(force: true)
+    deliver(force: true, skip_screenshots: true, skip_metadata: true, submit_for_review: true)
   end
 
   after_all do |lane|
     # This block is called, only if the executed lane was successful
+    if !is_ci
+      notification(subtitle: "Fastlane", message: "Finished successfully 🙌")
+    end
   end
 
   error do |lane, exception|
@@ -66,6 +120,11 @@ platform :ios do
         message: exception.message,
         success: false
       )
+    else
+      notification(subtitle: "Fastlane encountered an error", message: exception.message)
     end
   end
 end
+
+# More information about multiple platforms in fastlane: https://github.com/KrauseFx/fastlane/blob/master/docs/Platforms.md
+# All available actions: https://github.com/KrauseFx/fastlane/blob/master/docs/Actions.md

--- a/Acast/README.md
+++ b/Acast/README.md
@@ -6,39 +6,79 @@ sudo gem install fastlane
 ```
 # Available Actions
 ## iOS
-### ios xcode
+### ios setup
 ```
-fastlane ios xcode
+fastlane ios setup
 ```
-Installs FixCode which disables the "Fix Issue" button in Xcode
+Call this lane when setting up a new development machine
+
+Remember to install Cocoapods before you run this by running `sudo gem install cocoapods`
+
+It does the following:
+
+- Asks you to enter your apple-id which will be used to authorize you on iTunes Connect
+
+- Copies the device frames we use for our screenshots to your home directory
+
+- Installs the pods our app is dependant on
+
+- Installs Xcode CLI
+
+- Installs Homebrew
+
+- Installs SwiftLint
+
+- Installs FixCode
+
+- Downloads and installs the required provisioning profiles
 ### ios certs
 ```
 fastlane ios certs
 ```
-Fetches the provisioning profiles so you can build locally and deploy to your device
+Downloads the provisioning profiles so you can build locally and deploy to your device
 ### ios test
 ```
 fastlane ios test
 ```
 Runs all the unit and ui tests
-### ios screens
+### ios version_patch
 ```
-fastlane ios screens
+fastlane ios version_patch
 ```
-Creates new screenshots and uploads them to iTunes Connect
+Bumps version. Type: patch
+### ios version_minor
+```
+fastlane ios version_minor
+```
+Bumps version. Type: minor
+### ios version_major
+```
+fastlane ios version_major
+```
+Bumps version. Type: major
 ### ios beta
 ```
 fastlane ios beta
 ```
 Submits a new Beta Build to Apple TestFlight
+### ios meta
+```
+fastlane ios meta
+```
+Uploads the metadata to iTunes Connect
+### ios screenshots
+```
+fastlane ios screenshots
+```
+Creates new screenshots and uploads them to iTunes Connect
 ### ios deploy
 ```
 fastlane ios deploy
 ```
-Deploys a new version to the App Store
+Compiles the app, uploads it to iTunes Connect and submits it for review
 
 ----
 
-Generate this documentation by running `fastlane docs`
-More information about fastlane can be found on [https://fastlane.tools](https://fastlane.tools).
-The documentation of fastlane can be found on [GitHub](https://github.com/KrauseFx/fastlane)
+This README.md is auto-generated and will be re-generated every time to run [fastlane](https://fastlane.tools).  
+More information about fastlane can be found on [https://fastlane.tools](https://fastlane.tools).  
+The documentation of fastlane can be found on [GitHub](https://github.com/fastlane/fastlane).

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This repository contains a few `fastlane` example setups that help you getting s
   - Text and device frames are added to screenshots using [frameit](https://github.com/fastlane/frameit)
   - Delivered to iTunes Connect using [deliver](https://github.com/fastlane/deliver)
 - Submission to App Store using [gym](https://github.com/fastlane/gym) and [deliver](https://github.com/fastlane/deliver)
+- A `setup` lane that helps us onboard new colleagues and set up new development machines
+- Version lanes that helps us to bump our current version number quickly and correctly
 
 <p align="center">
   <a href="/Acast/">Overview</a> &bull;


### PR DESCRIPTION
I went bananas on our last hackday and created a `setup` lane. I used it yesterday when a second iOS Developer joined and it was great. Saved us so much time!

The purpose of the `setup` lane is to make sure the developer can start coding as soon as possible. Check the fastlane docs or `Fastfile` to see what is installed.

I want each developer to use their own apple-id instead of having to share a single account to iTunes Connect and Member center. Mainly because it would mean that we would have to change the password everytime somebody quits (not that this is an issue now, but I want to create something that can scale).

So in the `setup` lane I ask the user to enter the apple-id which is going to be used for developing. The apple-id is then written to a file named `appleId`. The file `appleId` is of course added to `.gitignore`.

In the `before_all` lane we check if the file `appleId` exists, if so we store the value into `ENV["DEVELOPER_EMAIL"]`. In the `Appfile` we set the property `apple_id` to `ENV["DEVELOPER_EMAIL"]`.

Maybe there's a better way of achieving this? Feedback would be great if something looks funky.
