### PR TITLE
Remove Firefox from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,26 +149,6 @@ This repository contains a few `fastlane` example setups that help you getting s
 
 ----
 
-### [Firefox](https://github.com/mozilla/firefox-ios) by Mozilla
-[![Firefox](Logos/Firefox.png)](https://github.com/mozilla/firefox-ios/)
-
-:cat2: **Advanced - submodules and custom actions**
-
-- Different Bundle Identifiers per `lane`
-- Custom enterprise deployment
-- `snapshot` setup with UI Tests
-- Advanced shell scripting
-
-<p align="center">
-  <a href="https://github.com/mozilla/firefox-ios-build-tools/tree/master/fastlane">Overview</a> &bull;
-  <a href="https://github.com/mozilla/firefox-ios-build-tools/blob/master/fastlane/BaseFastfile">Fastfile</a> &bull;
-  <a href="https://github.com/mozilla/firefox-ios-build-tools/blob/master/fastlane/Snapfile">Snapfile</a> &bull;
-  <a href="https://github.com/mozilla/firefox-ios/blob/master/ClientUITests/snapshot/MarketingSnapshotTests.swift">SnapshotTests.swift</a> &bull;
-  <a href="https://github.com/mozilla/firefox-ios-build-tools/tree/master/fastlane/actions">Custom Actions</a>
-</p>
-
-----
-
 ### [MindNode](https://mindnode.com/)
 [![MindNode](Logos/MindNode.png)](https://mindnode.com/)
 


### PR DESCRIPTION
It seems like the Firefox example isn't present anymore; this remove it from the Readme as well.